### PR TITLE
[GRAPHQL-148] Set operationName if passed in through options

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports.execute = () => ({
     body: {
       query: options.query,
       variables: options.variables,
-      operationName: null,
+      operationName: options.operationName ? options.operationName : null,
     },
     headers: _.extend({ 'User-Agent': 'oc' }, headers),
     json: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-graphql-client",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "OpenComponents client plugin for GraphQL",
   "main": "index.js",
   "author": "Chris Cartlidge <ccartlidge@opentable.com>",


### PR DESCRIPTION
Previously `operationName` was explicitly set to `null`. Allow consumers to pass in `operationName` through options.